### PR TITLE
bump Mastodon.py dependency for python 3.7 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-Mastodon.py==1.2.1
+Mastodon.py==1.3.1
 markovify==0.7.1
 beautifulsoup4==4.6.0


### PR DESCRIPTION
pulls in the upstream fix for https://github.com/halcy/Mastodon.py/issues/120